### PR TITLE
invalidate cell id without using macroexpand

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,30 @@
+name: PlutoHooks tests
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - "*.md"
+    branches:
+      - main
+  pull_request:
+    paths-ignore:
+      - "*.md"
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      matrix: # we don't depend on os specific feature, so keeping it minimal
+        julia-version: ["1.6"]
+        os: ["ubuntu-latest"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: julia-actions/setup-julia@v1
+        with:
+          - version: ${{ matrix.julia-version }}
+
+      - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -11,3 +11,11 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 julia = "1.6"
+
+[extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Pluto", "Pkg"]

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -1,0 +1,11 @@
+function noerror(cell)
+    errored = cell.errored
+    if errored
+        @show cell.output
+    end
+    !errored
+end
+
+function setcode(cell, code)
+    cell.code = code
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,191 @@
+using Test
+
+# TODO: use a fixed version of Pluto, once 0.17.1 + x has been released
+#       This is currently testing against Pluto#main
+import Pkg
+Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="main")
+
+import Pluto
+import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, ClientSession, update_run!
+
+include("./helpers.jl")
+
+🍭 = ServerSession()
+🍭.options.evaluation.workspace_use_distributed = false
+
+fakeclient = ClientSession(:fake, nothing)
+🍭.connected_clients[fakeclient.id] = fakeclient
+
+@testset "Use ref" begin
+    @testset "Implicit & explicit runs" begin
+        notebook = Notebook(Cell.([
+            "using PlutoHooks",
+            "x = 1",
+            """
+            begin
+                x;
+                ref = @use_ref(1)
+
+                ref[] += 1
+            end
+            """,
+        ]))
+        cell(idx) = notebook.cells[idx]
+
+        update_run!(🍭, notebook, notebook.cells)
+
+        @test cell(1) |> noerror
+        @test cell(2) |> noerror
+        @test cell(3) |> noerror
+        @test cell(3).output.body == "2"
+
+        update_run!(🍭, notebook, cell(2))
+
+        @test cell(3).output.body == "3"
+
+        for _ in 1:3
+            update_run!(🍭, notebook, cell(2))
+        end
+
+        @test cell(3).output.body == "6"
+
+        update_run!(🍭, notebook, cell(3))
+
+        @test cell(3).output.body == "2"
+    end
+end
+
+@testset "Use Effect" begin
+    @testset "Implicit runs with dependencies" begin
+        notebook = Notebook(Cell.([
+            "using PlutoHooks",
+            "x = 1",
+            "y = 1",
+            """
+            begin
+                y
+                ref = @use_ref(1)
+                @use_effect([x]) do
+                    ref[] += 1
+                end
+                ref[]
+            end
+            """,
+        ]))
+        cell(idx) = notebook.cells[idx]
+        update_run!(🍭, notebook, notebook.cells)
+
+        @test cell(4) |> noerror
+        @test cell(4).output.body == "2"
+
+        update_run!(🍭, notebook, cell(3))
+        @test cell(4).output.body == "2"
+
+        update_run!(🍭, notebook, cell(2)) # Not changing the value of x
+        @test cell(4).output.body == "2"
+
+        setcode(cell(2), "x = 2")
+        update_run!(🍭, notebook, cell(2)) # Changing the value of x
+        @test cell(4).output.body == "3"
+    end
+
+    @testset "Cleanups" begin
+        notebook = Notebook(Cell.([
+            "using PlutoHooks",
+            "cleanup_ref = @use_ref(1)",
+            "ref = @use_ref(1)",
+            "x = 1",
+            """
+            begin
+                @use_effect([x]) do
+                    ref[] += 1
+                    () -> (cleanup_ref[] += 1)
+                end
+            end
+            """,
+            "cleanup_ref[]",
+        ]))
+        cell(idx) = notebook.cells[idx]
+        update_run!(🍭, notebook, notebook.cells)
+
+        @test all(noerror, notebook.cells)
+        @test cell(6).output.body == "1"
+
+        update_run!(🍭, notebook, [cell(4), cell(6)])
+        @test cell(6).output.body == "1"
+
+        setcode(cell(4), "x = 2")
+        update_run!(🍭, notebook, [cell(4), cell(6)])
+        @test cell(6).output.body == "2"
+
+        update_run!(🍭, notebook, [cell(5), cell(6)])
+        @test cell(6).output.body == "3"
+    end
+end
+
+@testset "Use state" begin
+    @testset "Trigger reactive run" begin
+        # Use state tests are distributed because the self run relaying is not closed for non-distributed notebooks
+        🍭.options.evaluation.workspace_use_distributed = true
+    
+        notebook = Notebook(Cell.([
+            "using PlutoHooks",
+            "state, setstate = @use_state(1)",
+            "trigger = false",
+            """
+            if trigger
+                setstate(10)
+            end
+            """,
+            "state",
+        ]))
+        cell(idx) = notebook.cells[idx]
+
+        update_run!(🍭, notebook, notebook.cells)
+
+        @test all(noerror, notebook.cells)
+        @test notebook.cells[end].output.body == "1"
+
+        setcode(cell(3), "trigger = true")
+        update_run!(🍭, notebook, cell(3))
+
+        sleep(.3) # Reactive run is async
+
+        @test notebook.cells[end].output.body == "10"
+
+        setcode(cell(3), "trigger = false")
+        update_run!(🍭, notebook, cell(3))
+        update_run!(🍭, notebook, cell(2))
+        
+        @test notebook.cells[end].output.body == "1"
+
+        WorkspaceManager.unmake_workspace((🍭, notebook))
+        🍭.options.evaluation.workspace_use_distributed = true
+    end
+end
+
+@testset "Use deps" begin
+    notebook = Notebook(Cell.([
+        "using PlutoHooks",
+        "x = 1",
+        """
+        @use_deps([x]) do
+            ref = @use_ref(1)
+
+            ref[] += 1
+        end
+        """,
+    ]))
+    cell(idx) = notebook.cells[idx]
+    update_run!(🍭, notebook, notebook.cells)
+
+    @test all(noerror, notebook.cells)
+    @test cell(3).output.body == "2"
+
+    update_run!(🍭, notebook, cell(2))
+    @test cell(3).output.body == "3"
+
+    setcode(cell(2), "x = 2")
+    update_run!(🍭, notebook, cell(2))
+    @test cell(3).output.body == "2"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,7 +160,7 @@ end
         @test notebook.cells[end].output.body == "1"
 
         WorkspaceManager.unmake_workspace((🍭, notebook))
-        🍭.options.evaluation.workspace_use_distributed = true
+        🍭.options.evaluation.workspace_use_distributed = false
     end
 end
 
@@ -188,4 +188,32 @@ end
     setcode(cell(2), "x = 2")
     update_run!(🍭, notebook, cell(2))
     @test cell(3).output.body == "2"
+end
+
+@testset "use task" begin
+    🍭.options.evaluation.workspace_use_distributed = true
+    notebook = Notebook(Cell.([
+        "using PlutoHooks",
+        """
+        begin
+            state, setstate = @use_state(1)
+            @use_task([]) do
+                sleep(.1)
+                setstate(2)
+            end
+        end
+        """,
+        "state"
+    ]))
+    update_run!(🍭, notebook, notebook.cells)
+
+    @test notebook.cells[3] |> noerror
+    @test notebook.cells[3].output.body == "1"
+
+    sleep(.3)
+
+    @test notebook.cells[3].output.body == "2"
+
+    WorkspaceManager.unmake_workspace((🍭, notebook))
+    🍭.options.evaluation.workspace_use_distributed = false
 end


### PR DESCRIPTION
fixes the problem of `macroexpanding(__module__, ex)` in `@use_deps`