### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Get hooked on Pluto! Bring your notebook to life! This is an abstraction based on [React.js Hooks](https://reactjs.org/docs/hooks-intro.html) to implement "react-like" features in [Pluto.jl](https://plutojl.org).
 It allows code cells to carry information and processes between updates, and even update themselves.
-This package contains only the low level hooks, the directly usable hooks have been moved in [PlutoLinks.jl](https://github.com/JuliaPluto/PlutoLinks.jl). You can take a look at the [PlutoHooks.jl sources](https://juliapluto.github.io/PlutoHooks.jl/src/notebook.html).
+The PlutoHooks macros are used as a foundation for the higher-level utlities in [PlutoLinks.jl](https://github.com/JuliaPluto/PlutoLinks.jl). The source code is written as a Pluto notebook, which also serves as [package documentation](https://juliapluto.github.io/PlutoHooks.jl/src/notebook.html).
 
 There is a lot you can do with this, but some examples:
-- Run a process and relay it's output to the rest of your notebook.
+- Maintain state between cell evaluations.
+- Run a process and relay its output to the rest of your notebook.
 - Watch a file and reload the content when it changes.
 - Do a computation on separate thread while the rest of notebook continue running.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Get hooked on Pluto! Bring your notebook to life! This is an abstraction based on [React.js Hooks](https://reactjs.org/docs/hooks-intro.html) to implement "react-like" features in [Pluto.jl](https://plutojl.org).
 It allows code cells to carry information and processes between updates, and even update themselves.
-The PlutoHooks macros are used as a foundation for the higher-level utlities in [PlutoLinks.jl](https://github.com/JuliaPluto/PlutoLinks.jl). The source code is written as a Pluto notebook, which also serves as [package documentation](https://juliapluto.github.io/PlutoHooks.jl/src/notebook.html).
+The PlutoHooks macros are used as a foundation for the higher-level utilities in [PlutoLinks.jl](https://github.com/JuliaPluto/PlutoLinks.jl). The source code is written as a Pluto notebook, which also serves as [package documentation](https://juliapluto.github.io/PlutoHooks.jl/src/notebook.html).
 
 There is a lot you can do with this, but some examples:
 - Maintain state between cell evaluations.


### PR DESCRIPTION
- Clarify that the best (current) documentation is the link to the HTML-ized notebook
- Removing the scary text "use PlutoLinks instead". Actually, this package is useful on its own!
- Add to the list of examples the ability to save state between cell evaluations.